### PR TITLE
Revert "Adding rust automerge"

### DIFF
--- a/default.json
+++ b/default.json
@@ -18,11 +18,8 @@
 		],
 		"rangeStrategy": "bump",
 		"bumpVersion": "patch",
-		"automergeType": "pr",
+		"automerge": false,
 		"updateLockFiles": true,
-		"major": {
-			"automerge": false
-		},
 		"packageRules": [
 			{
 				"description": "merge minor and patch updates into a single PR",
@@ -33,9 +30,7 @@
 				"matchUpdateTypes": [
 					"minor",
 					"patch"
-				],
-				"automerge": true,
-				"stabilityDays": 3
+				]
 			}
 		]
 	},


### PR DESCRIPTION
Reverts digicatapult/renovate-config#85
Due to `bumpVersion` not being supported by the cargo package manager.