### PR TITLE
exclude python version upgrades

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/renovate-config",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/renovate-config",
-      "version": "0.3.18",
+      "version": "0.3.19",
       "license": "Apache-2.0",
       "devDependencies": {
         "renovate": "^37.56.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/renovate-config",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Renovate Preset for Digital Catapult",
   "files": [
     "default.json",

--- a/poetry.json
+++ b/poetry.json
@@ -34,6 +34,12 @@
 					"patch"
 				],
 				"stabilityDays": 3
+			},
+			{
+				"matchPackageNames": [
+					"python"
+				],
+				"enabled": false
 			}
 		]
 	}


### PR DESCRIPTION
Excludes python itself from being upgraded as a poetry dep as this causes CI to fail.