### PR TITLE
Combined prettier and eslint-plugin-prettier into a single PR

### DIFF
--- a/default.json
+++ b/default.json
@@ -70,6 +70,18 @@
 					"engines"
 				],
 				"enabled": false
+			},
+			{
+				"description": "upgrade eslint-plugin-prettier to v5 and prettier to v3 in a single PR",
+				"matchPackageNames": [
+					"eslint-plugin-prettier",
+					"prettier"
+				],
+				"matchVersions": [
+					"5.x",
+					"3.x"
+				],
+				"groupName": "eslint-plugin-prettier v5 and prettier v3 upgrade"
 			}
 		]
 	},


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Feature

## Linked tickets

N/A

## High level description

This PR should ensure that the eslint-plugin-prettier and prettier deps get upgraded in tandem and that they are able to be merged together

## Detailed description

Currently upgrading the major versions of these by themselves is unmergable because they actually need to be merged in tandem.


## Describe alternatives you've considered

N/A

## Operational impact

This will generate new PRs across all repositories, they will not automatically merge so we can review.  Should this not result in passing tests then we can revert this PR and the generated PRs will automatically close.

## Additional context

N/A
