### PR TITLE
TSOA updates to 6.3.1 removed

### DIFF
--- a/default.json
+++ b/default.json
@@ -62,7 +62,10 @@
 					"patch"
 				],
 				"automerge": true,
-				"stabilityDays": 3
+				"stabilityDays": 3,
+				"excludePackagePatterns": [
+					"tsoa@6.3.1"
+				]
 			},
 			{
 				"description": "disable package.json > engines update",
@@ -82,6 +85,10 @@
 					"3.x"
 				],
 				"groupName": "eslint-plugin-prettier v5 and prettier v3 upgrade"
+			},
+			{
+				"packageNames": ["tsoa"],
+				"allowedVersions": "!=6.3.1"
 			}
 		]
 	},


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Feature

## Linked tickets

N/A

## High level description

Removes TSOA 6.3.1 updates

## Detailed description

Stops us from upgrading to TSOA 6.3.1 due to a bug.


## Describe alternatives you've considered

N/A

## Operational impact

If this doesn't work then we can revert

## Additional context

N/A
