### PR TITLE
Pins typescript

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Use Node.js v18.x
+    - name: Use Node.js v20.x
       uses: actions/setup-node@v4
       with:
-        node-version: 18.x
+        node-version: 20.x
     - name: Cache Node.js modules
       uses: actions/cache@v4
       with:

--- a/default.json
+++ b/default.json
@@ -75,26 +75,6 @@
 				"enabled": false
 			},
 			{
-				"description": "upgrade eslint-plugin-prettier to v5 and prettier to v3 in a single PR",
-				"matchPackageNames": [
-					"eslint-plugin-prettier",
-					"prettier"
-				],
-				"matchVersions": [
-					"5.x",
-					"3.x"
-				],
-				"groupName": "eslint-plugin-prettier v5 and prettier v3 upgrade"
-			},
-			{
-				"matchPackageNames": [
-					"tsoa"
-				],
-				"ignoreVersions": [
-					"6.3.1"
-				]
-			},
-			{
 				"description": "Downgrade TypeScript to version 5.5.4",
 				"matchPackageNames": [
 					"typescript"

--- a/default.json
+++ b/default.json
@@ -1,6 +1,6 @@
 {
 	"extends": [
-		"config:base",
+		"config:recommended",
 		":rebaseStalePrs",
 		":timezone(Europe/London)"
 	],
@@ -40,7 +40,7 @@
 			"npm"
 		],
 		"extends": [
-			":unpublishSafe",
+			"npm:unpublishSafe",
 			"helpers:disableTypesNodeMajor"
 		],
 		"rangeStrategy": "bump",
@@ -62,12 +62,14 @@
 					"patch"
 				],
 				"automerge": true,
-				"stabilityDays": 3,
-				"excludePackageNames": ["tsoa"]
+				"minimumReleaseAge": "3 days",
+				"matchPackageNames": [
+					"!tsoa"
+				]
 			},
 			{
 				"description": "disable package.json > engines update",
-				"depTypeList": [
+				"matchDepTypes": [
 					"engines"
 				],
 				"enabled": false
@@ -85,12 +87,18 @@
 				"groupName": "eslint-plugin-prettier v5 and prettier v3 upgrade"
 			},
 			{
-				"packageNames": ["tsoa"],
-				"ignoreVersions": ["6.3.1"]
+				"matchPackageNames": [
+					"tsoa"
+				],
+				"ignoreVersions": [
+					"6.3.1"
+				]
 			},
 			{
 				"description": "Downgrade TypeScript to version 5.5.4",
-				"matchPackageNames": ["typescript"],
+				"matchPackageNames": [
+					"typescript"
+				],
 				"allowedVersions": "5.5.4",
 				"rangeStrategy": "pin"
 			}
@@ -102,9 +110,12 @@
 			"github-actions"
 		],
 		"groupName": "GitHub Actions - updates",
-		"packageRules":[
-			{ "matchUpdateTypes": ["major"],
-			  "matchPackageNames": [
+		"packageRules": [
+			{
+				"matchUpdateTypes": [
+					"major"
+				],
+				"matchPackageNames": [
 					"actions/checkout",
 					"actions/setup-node",
 					"actions/setup-python",
@@ -115,7 +126,7 @@
 				"extends": [
 					"schedule:automergeNonOfficeHours"
 				]
-				}
+			}
 		]
 	},
 	"packageRules": [

--- a/default.json
+++ b/default.json
@@ -87,6 +87,12 @@
 			{
 				"packageNames": ["tsoa"],
 				"ignoreVersions": ["6.3.1"]
+			},
+			{
+				"description": "Downgrade TypeScript to version 5.5.4",
+				"matchPackageNames": ["typescript"],
+				"allowedVersions": "5.5.4",
+				"rangeStrategy": "pin"
 			}
 		]
 	},

--- a/helm.json
+++ b/helm.json
@@ -7,7 +7,7 @@
 		"github-actions",
 		"helmv3",
 		"helm-values",
-		"regex"
+		"custom.regex"
 	],
 	"helmv3": {
 		"automerge": false
@@ -15,8 +15,9 @@
 	"helm-values": {
 		"automerge": false
 	},
-	"regexManagers": [
+	"customManagers": [
 		{
+			"customType": "regex",
 			"fileMatch": [
 				"(^|/)Chart\\.yaml$"
 			],
@@ -32,11 +33,15 @@
 			"matchManagers": [
 				"helmv3",
 				"helm-values",
-				"regex"
+				"custom.regex"
 			],
 			"bumpVersion": "patch",
 			"automerge": false,
-			"matchUpdateTypes": ["major", "minor", "patch"],
+			"matchUpdateTypes": [
+				"major",
+				"minor",
+				"patch"
+			],
 			"labels": [
 				"dependencies",
 				"helm"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "renovate": "^38.74.1"
       },
       "engines": {
-        "node": ">=18.13.0"
+        "node": ">= 20"
       }
     },
     "node_modules/@arcanis/slice-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/renovate-config",
-  "version": "0.3.368",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/renovate-config",
-      "version": "0.3.368",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "renovate": "^38.73.3"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
 	"author": "Digital Catapult (https://www.digicatapult.org.uk/)",
   "scripts": {
-    "test": "renovate-config-validator"
+    "test": "renovate-config-validator default.json helm.json poetry.json"
   },
   "devDependencies": {
     "renovate": "^38.73.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/renovate-config",
-  "version": "0.3.368",
+  "version": "0.4.0",
   "description": "Renovate Preset for Digital Catapult",
   "files": [
     "default.json",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "homepage": "https://github.com/digicatapult/renovate-config",
   "license": "Apache-2.0",
 	"engines": {
-    "node": ">=18.13.0"
+    "node": ">= 20"
   },
 	"author": "Digital Catapult (https://www.digicatapult.org.uk/)",
   "scripts": {

--- a/poetry.json
+++ b/poetry.json
@@ -33,7 +33,7 @@
 					"minor",
 					"patch"
 				],
-				"stabilityDays": 3
+				"minimumReleaseAge": "3 days"
 			},
 			{
 				"matchPackageNames": [


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix
- [X] Feature

## Linked tickets

N/A

## High level description

Experiment to see if we can to a version that we have already exceeded using renovate

## Detailed description

To fix the tsimp/typescript issue which causes all our tests to silently fail we pin the typescript version.
Fixes formatting on the renovate configs.
Fixes workflow so we run `renovate-config-validator` on the actual configs we use instead of `renovate.json`.
Removes some rules that are no longer needed.
Updates configs to the latest version, as we were using some old/deprecated keys.
Updates us to using node 20 for the renovate package.


## Describe alternatives you've considered

N/A
## Operational impact

It might not work.
## Additional context

N/A
