### PR TITLE
Removed non-functional downgrade typescript rule

### DIFF
--- a/default.json
+++ b/default.json
@@ -73,14 +73,6 @@
 					"engines"
 				],
 				"enabled": false
-			},
-			{
-				"description": "Downgrade TypeScript to version 5.5.4",
-				"matchPackageNames": [
-					"typescript"
-				],
-				"allowedVersions": "5.5.4",
-				"rangeStrategy": "pin"
 			}
 		]
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/renovate-config",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/renovate-config",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "renovate": "^38.77.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/renovate-config",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Renovate Preset for Digital Catapult",
   "files": [
     "default.json",


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix

## Linked tickets


## High level description

Reverts the PackageRule to downgrade Typescript

## Detailed description

Downgrades are not currently supported by renovateBot as per https://github.com/renovatebot/renovate/discussions/31415


## Describe alternatives you've considered

N/A

## Operational impact

N/A

## Additional context

N/A
