### PR TITLE
Always recreate NPM + Poetry PRs

### DIFF
--- a/default.json
+++ b/default.json
@@ -47,6 +47,7 @@
 		"bumpVersion": "patch",
 		"automergeType": "pr",
 		"updateLockFiles": true,
+		"recreateWhen": "always",
 		"major": {
 			"automerge": false
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/renovate-config",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/renovate-config",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "Apache-2.0",
       "devDependencies": {
         "renovate": "^38.77.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/renovate-config",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Renovate Preset for Digital Catapult",
   "files": [
     "default.json",

--- a/poetry.json
+++ b/poetry.json
@@ -19,6 +19,7 @@
 		"updateLockFiles": true,
 		"rangeStrategy": "bump",
 		"bumpVersion": "patch",
+		"recreateWhen": "always",
 		"major": {
 			"automerge": false
 		},


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix
- [x] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/ENG-105

## High level description

Will mean if you close an NPM PR, Renovate will always recreate it

## Operational impact

We won't be able to remove NPM PRs unless we change this setting back.

