### PR TITLE
Add non-production labels repo list

### DIFF
--- a/default.json
+++ b/default.json
@@ -121,6 +121,14 @@
 				"dependencies",
 				"docker"
 			]
-		}
+		},
+		{
+			"description": "Apply non-production labels to all non-production repos.",
+			"matchRepositories": [
+			  "digicatapult/bridgeAI*",
+			  "digicatapult/nice-fetch-ai-adapter"
+			],
+			"labels": ["non-production"]
+		  }
 	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/renovate-config",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/renovate-config",
-      "version": "0.4.25",
+      "version": "0.4.26",
       "license": "Apache-2.0",
       "devDependencies": {
         "renovate": "^38.110.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/renovate-config",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "description": "Renovate Preset for Digital Catapult",
   "files": [
     "default.json",


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Feature

## Linked tickets

https://digicatapult.atlassian.net/browse/ENG-107

## High level description

Start a blacklist of non-production repositories. Their Renovate PRs will be labelled `non-production` so they can be easily filtered.


## Describe alternatives you've considered

A blacklist is safer than a whitelist since whitelisting could mean we ignore Renovate on repos without realising.