### PR TITLE
Add non-production label to rest of labels instead of replacing

### DIFF
--- a/default.json
+++ b/default.json
@@ -128,7 +128,7 @@
 			  "digicatapult/bridgeAI*",
 			  "digicatapult/nice-fetch-ai-adapter"
 			],
-			"labels": ["non-production"]
+			"addLabels": ["non-production"]
 		  }
 	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/renovate-config",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/renovate-config",
-      "version": "0.4.26",
+      "version": "0.4.27",
       "license": "Apache-2.0",
       "devDependencies": {
         "renovate": "^38.110.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/renovate-config",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "description": "Renovate Preset for Digital Catapult",
   "files": [
     "default.json",


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix

## Linked tickets

https://digicatapult.atlassian.net/browse/ENG-107

## High level description

See https://docs.renovatebot.com/configuration-options/#addlabels. We want `non-production` to be a label on top of other standard labels rather than the only label.

