### PR TITLE
feat: add terraform preset for tf/terragrunt repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,50 @@ Add this into your application repositories `renovate.json`:
 }
 ```
 
+#### Terraform / Terragrunt repositories
+
+For repositories containing Terraform or Terragrunt infrastructure code (e.g. `*-tf-infra`, `*-terragrunt-infra`), use the `terraform` preset instead:
+
+```json
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["github>digicatapult/renovate-config:terraform"]
+}
+```
+
+This preset enables managers for:
+
+- `.tf` files — Terraform providers, registry modules, and `required_version` constraints
+- `terragrunt.hcl` files — Terragrunt module sources
+- `.terraform-version` and `.terragrunt-version` — CLI version pinning (asdf/tfenv style)
+- GitHub Actions workflows (inherited from the default preset)
+
+Behaviour:
+
+- **No automerge** for any Terraform-related update — every change requires a human review of the resulting `terraform plan`.
+- **Grouped PRs** — minor and patch updates for providers / modules are batched into a single PR per ecosystem to reduce noise; major updates get their own PR labeled `major-update`.
+- **Business hours only** — PRs are opened Monday–Friday, 09:00–17:00 (Europe/London) so reviewers are available.
+- **Rate limited** — at most 2 new PRs per hour and 5 concurrent open PRs.
+- **3-day stability wait** for grouped minor/patch updates to avoid pulling in immediately-yanked releases.
+
+#### Flux repositories
+
+```json
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["github>digicatapult/renovate-config:flux"]
+}
+```
+
+#### Helm chart repositories
+
+```json
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["github>digicatapult/renovate-config:helm"]
+}
+```
+
 ## Links
 
 - [Configuration Options](https://renovatebot.com/docs/configuration-options)

--- a/terraform.json
+++ b/terraform.json
@@ -12,11 +12,25 @@
 	],
 	"prHourlyLimit": 2,
 	"prConcurrentLimit": 5,
+	"schedule": [
+		"* 9-17 * * 1-5"
+	],
+	"labels": [
+		"dependencies"
+	],
+	"minimumReleaseAge": "3 days",
+	"separateMajorMinor": true,
 	"terraform": {
-		"rangeStrategy": "bump"
+		"rangeStrategy": "bump",
+		"addLabels": [
+			"terraform"
+		]
 	},
 	"terragrunt": {
 		"rangeStrategy": "bump",
+		"addLabels": [
+			"terragrunt"
+		],
 		"lockFileMaintenance": {
 			"enabled": true,
 			"recreateWhen": "always",
@@ -26,11 +40,21 @@
 				"after 12pm on sunday"
 			],
 			"addLabels": [
-				"dependencies",
-				"terraform",
 				"lock-files"
 			]
 		}
+	},
+	"terraform-version": {
+		"addLabels": [
+			"terraform",
+			"tooling"
+		]
+	},
+	"terragrunt-version": {
+		"addLabels": [
+			"terragrunt",
+			"tooling"
+		]
 	},
 	"packageRules": [
 		{
@@ -46,41 +70,10 @@
 				"minor",
 				"patch"
 			],
-			"groupName": "terraform providers - minor and patch updates",
-			"labels": [
-				"dependencies",
-				"terraform"
-			],
-			"schedule": [
-				"* 9-17 * * 1-5"
-			],
-			"automerge": false,
-			"minimumReleaseAge": "3 days"
+			"groupName": "terraform providers - minor and patch updates"
 		},
 		{
-			"description": "Terraform provider major updates - separate PR, never automerged",
-			"matchManagers": [
-				"terraform"
-			],
-			"matchDepTypes": [
-				"provider",
-				"required_provider"
-			],
-			"matchUpdateTypes": [
-				"major"
-			],
-			"labels": [
-				"dependencies",
-				"terraform",
-				"major-update"
-			],
-			"schedule": [
-				"* 9-17 * * 1-5"
-			],
-			"automerge": false
-		},
-		{
-			"description": "Group Terraform module (registry/local) minor and patch updates from .tf files",
+			"description": "Group Terraform module (registry/local) minor and patch updates",
 			"matchManagers": [
 				"terraform"
 			],
@@ -91,37 +84,7 @@
 				"minor",
 				"patch"
 			],
-			"groupName": "terraform modules - minor and patch updates",
-			"labels": [
-				"dependencies",
-				"terraform"
-			],
-			"schedule": [
-				"* 9-17 * * 1-5"
-			],
-			"automerge": false,
-			"minimumReleaseAge": "3 days"
-		},
-		{
-			"description": "Terraform module major updates from .tf files - separate PR, never automerged",
-			"matchManagers": [
-				"terraform"
-			],
-			"matchDepTypes": [
-				"module"
-			],
-			"matchUpdateTypes": [
-				"major"
-			],
-			"labels": [
-				"dependencies",
-				"terraform",
-				"major-update"
-			],
-			"schedule": [
-				"* 9-17 * * 1-5"
-			],
-			"automerge": false
+			"groupName": "terraform modules - minor and patch updates"
 		},
 		{
 			"description": "Group Terragrunt module sources (registry/GitHub/Git) minor and patch updates",
@@ -137,89 +100,22 @@
 				"minor",
 				"patch"
 			],
-			"groupName": "terragrunt modules - minor and patch updates",
-			"labels": [
-				"dependencies",
-				"terragrunt"
-			],
-			"schedule": [
-				"* 9-17 * * 1-5"
-			],
-			"automerge": false,
-			"minimumReleaseAge": "3 days"
+			"groupName": "terragrunt modules - minor and patch updates"
 		},
 		{
-			"description": "Terragrunt module sources major updates - separate PR, never automerged",
+			"description": "Label all major updates clearly so they stand out for review",
 			"matchManagers": [
-				"terragrunt"
-			],
-			"matchDepTypes": [
+				"terraform",
 				"terragrunt",
-				"github",
-				"gitTags"
+				"terraform-version",
+				"terragrunt-version"
 			],
 			"matchUpdateTypes": [
 				"major"
 			],
-			"labels": [
-				"dependencies",
-				"terragrunt",
+			"addLabels": [
 				"major-update"
-			],
-			"schedule": [
-				"* 9-17 * * 1-5"
-			],
-			"automerge": false
-		},
-		{
-			"description": "Terraform required_version constraints in .tf files",
-			"matchManagers": [
-				"terraform"
-			],
-			"matchDepTypes": [
-				"required_version"
-			],
-			"labels": [
-				"dependencies",
-				"terraform",
-				"tooling"
-			],
-			"schedule": [
-				"* 9-17 * * 1-5"
-			],
-			"automerge": false
-		},
-		{
-			"description": "Terraform CLI version pinned in .terraform-version",
-			"matchManagers": [
-				"terraform-version"
-			],
-			"groupName": "terraform CLI",
-			"labels": [
-				"dependencies",
-				"terraform",
-				"tooling"
-			],
-			"schedule": [
-				"* 9-17 * * 1-5"
-			],
-			"automerge": false
-		},
-		{
-			"description": "Terragrunt CLI version pinned in .terragrunt-version",
-			"matchManagers": [
-				"terragrunt-version"
-			],
-			"groupName": "terragrunt CLI",
-			"labels": [
-				"dependencies",
-				"terragrunt",
-				"tooling"
-			],
-			"schedule": [
-				"* 9-17 * * 1-5"
-			],
-			"automerge": false
+			]
 		}
 	]
 }

--- a/terraform.json
+++ b/terraform.json
@@ -1,0 +1,225 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		"github>digicatapult/renovate-config"
+	],
+	"enabledManagers": [
+		"terraform",
+		"terragrunt",
+		"terraform-version",
+		"terragrunt-version",
+		"github-actions"
+	],
+	"prHourlyLimit": 2,
+	"prConcurrentLimit": 5,
+	"terraform": {
+		"rangeStrategy": "bump"
+	},
+	"terragrunt": {
+		"rangeStrategy": "bump",
+		"lockFileMaintenance": {
+			"enabled": true,
+			"recreateWhen": "always",
+			"rebaseWhen": "behind-base-branch",
+			"branchTopic": "terraform-lock-maintenance",
+			"schedule": [
+				"after 12pm on sunday"
+			],
+			"addLabels": [
+				"dependencies",
+				"terraform",
+				"lock-files"
+			]
+		}
+	},
+	"packageRules": [
+		{
+			"description": "Group Terraform provider minor and patch updates into a single PR",
+			"matchManagers": [
+				"terraform"
+			],
+			"matchDepTypes": [
+				"provider",
+				"required_provider"
+			],
+			"matchUpdateTypes": [
+				"minor",
+				"patch"
+			],
+			"groupName": "terraform providers - minor and patch updates",
+			"labels": [
+				"dependencies",
+				"terraform"
+			],
+			"schedule": [
+				"* 9-17 * * 1-5"
+			],
+			"automerge": false,
+			"minimumReleaseAge": "3 days"
+		},
+		{
+			"description": "Terraform provider major updates - separate PR, never automerged",
+			"matchManagers": [
+				"terraform"
+			],
+			"matchDepTypes": [
+				"provider",
+				"required_provider"
+			],
+			"matchUpdateTypes": [
+				"major"
+			],
+			"labels": [
+				"dependencies",
+				"terraform",
+				"major-update"
+			],
+			"schedule": [
+				"* 9-17 * * 1-5"
+			],
+			"automerge": false
+		},
+		{
+			"description": "Group Terraform module (registry/local) minor and patch updates from .tf files",
+			"matchManagers": [
+				"terraform"
+			],
+			"matchDepTypes": [
+				"module"
+			],
+			"matchUpdateTypes": [
+				"minor",
+				"patch"
+			],
+			"groupName": "terraform modules - minor and patch updates",
+			"labels": [
+				"dependencies",
+				"terraform"
+			],
+			"schedule": [
+				"* 9-17 * * 1-5"
+			],
+			"automerge": false,
+			"minimumReleaseAge": "3 days"
+		},
+		{
+			"description": "Terraform module major updates from .tf files - separate PR, never automerged",
+			"matchManagers": [
+				"terraform"
+			],
+			"matchDepTypes": [
+				"module"
+			],
+			"matchUpdateTypes": [
+				"major"
+			],
+			"labels": [
+				"dependencies",
+				"terraform",
+				"major-update"
+			],
+			"schedule": [
+				"* 9-17 * * 1-5"
+			],
+			"automerge": false
+		},
+		{
+			"description": "Group Terragrunt module sources (registry/GitHub/Git) minor and patch updates",
+			"matchManagers": [
+				"terragrunt"
+			],
+			"matchDepTypes": [
+				"terragrunt",
+				"github",
+				"gitTags"
+			],
+			"matchUpdateTypes": [
+				"minor",
+				"patch"
+			],
+			"groupName": "terragrunt modules - minor and patch updates",
+			"labels": [
+				"dependencies",
+				"terragrunt"
+			],
+			"schedule": [
+				"* 9-17 * * 1-5"
+			],
+			"automerge": false,
+			"minimumReleaseAge": "3 days"
+		},
+		{
+			"description": "Terragrunt module sources major updates - separate PR, never automerged",
+			"matchManagers": [
+				"terragrunt"
+			],
+			"matchDepTypes": [
+				"terragrunt",
+				"github",
+				"gitTags"
+			],
+			"matchUpdateTypes": [
+				"major"
+			],
+			"labels": [
+				"dependencies",
+				"terragrunt",
+				"major-update"
+			],
+			"schedule": [
+				"* 9-17 * * 1-5"
+			],
+			"automerge": false
+		},
+		{
+			"description": "Terraform required_version constraints in .tf files",
+			"matchManagers": [
+				"terraform"
+			],
+			"matchDepTypes": [
+				"required_version"
+			],
+			"labels": [
+				"dependencies",
+				"terraform",
+				"tooling"
+			],
+			"schedule": [
+				"* 9-17 * * 1-5"
+			],
+			"automerge": false
+		},
+		{
+			"description": "Terraform CLI version pinned in .terraform-version",
+			"matchManagers": [
+				"terraform-version"
+			],
+			"groupName": "terraform CLI",
+			"labels": [
+				"dependencies",
+				"terraform",
+				"tooling"
+			],
+			"schedule": [
+				"* 9-17 * * 1-5"
+			],
+			"automerge": false
+		},
+		{
+			"description": "Terragrunt CLI version pinned in .terragrunt-version",
+			"matchManagers": [
+				"terragrunt-version"
+			],
+			"groupName": "terragrunt CLI",
+			"labels": [
+				"dependencies",
+				"terragrunt",
+				"tooling"
+			],
+			"schedule": [
+				"* 9-17 * * 1-5"
+			],
+			"automerge": false
+		}
+	]
+}


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Feature

## Linked tickets

N/A

## High level description

Adds a new `terraform.json` preset for the org's `*-tf-infra` and `*-terragrunt-infra` repositories so Renovate can keep their Terraform / Terragrunt / provider / CLI versions up to date in a way that's safe to review (no automerge, business-hours PRs, sensible grouping).

## Detailed description

The new preset is consumed via:

```json
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": ["github>digicatapult/renovate-config:terraform"]
}
```

It enables four Renovate managers:

- `terraform` - `.tf` / `.tofu` files. Extracts providers (`provider`, `required_provider`), modules (`module`), and `required_version` constraints. Also picks up `helm_release` and Kubernetes / Docker resource image references for free.
- `terragrunt` - `terragrunt.hcl` files. Extracts module sources from the Terraform Registry (`terragrunt`), GitHub (`github`) and generic Git (`gitTags`).
- `terraform-version` - `.terraform-version` (asdf / tfenv pin file). Tracks Hashicorp Terraform releases.
- `terragrunt-version` - `.terragrunt-version`. Tracks `gruntwork-io/terragrunt` GitHub releases.
- Inherits `github-actions` from the existing default preset for workflow updates.

Behaviour:

- **No automerge** for any Terraform-related update - every change requires human review of the resulting `terraform plan`.
- **Grouped PRs** - minor + patch updates for providers / modules / CLIs are batched per ecosystem; major updates get their own PR labeled `major-update`.
- **Business hours only** - PRs open Mon-Fri 09:00-17:00 (Europe/London).
- **Rate limited** - max 2 new PRs per hour, 5 concurrent open PRs.
- **3-day stability wait** for grouped minor/patch updates to avoid pulling in immediately-yanked releases.
- **Lock file maintenance** for `.terraform.lock.hcl` is enabled via the terragrunt manager, matching the existing pattern used for cargo/npm in `default.json`.

Pre-flight investigation looked at the following infra repos to confirm the structures and tooling versions in use across the org: `veritable-terragrunt-infra`, `sqnc-terragrunt-infra`, `eng-terragrunt-infra`, `spec-rag-tf-infra`, `bridgeAI-tf-infra`, `dtdl-tf-infra`, `ukdtc-dtaas-workbench-tf-infra`, `dsbd-lab-infra`. None of these currently has a `renovate.json`, so this is greenfield.

Validated locally with `renovate-config-validator terraform.json` (passes) and `python3 -m json.tool` (valid JSON).

## Describe alternatives you've considered

- **Folding terraform managers into `default.json`.** Rejected - infra repos have a different review cadence and risk profile from app repos. A separate preset means infra repos opt in explicitly and don't inherit npm/cargo grouping that doesn't apply.
- **Automerge patch-level provider bumps.** Rejected for now - even a patch on `azurerm` can produce non-trivial plan diffs, and there's no `terraform plan` gate in CI across these repos yet. Worth revisiting once that's in place.
- **Custom regex managers for Helm chart versions and image tags inside `.tf`.** Rejected for the initial preset to keep it minimal; repos can add their own custom managers if they want this. The `terraform` manager already extracts `helm_release` and Kubernetes pod image references natively, which covers the common cases.

## Operational impact

- Existing repos see no change until they explicitly add a `renovate.json` extending `:terraform`. Renovate will open a standard onboarding PR on first run so the config is reviewable.
- All Terraform-related PRs require human merge - expect roughly weekly batched PRs per ecosystem.
- Reverting the preset is a single-file revert; no state to clean up.

## Additional context

Verified all manager names and `depType` values against the [Renovate manager docs](https://docs.renovatebot.com/modules/manager/) before shipping. Notably, the `terragrunt` manager uses depType values `terragrunt` / `github` / `gitTags` (not `module` like the `terraform` manager) - the rules are split accordingly.
