### PR TITLE
Pin boto3 Renovate updates

### DIFF
--- a/poetry.json
+++ b/poetry.json
@@ -1,42 +1,58 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>digicatapult/renovate-config"],
-  "enabledManagers": [
-    "npm",
-    "dockerfile",
-    "docker-compose",
-    "github-actions",
-    "cargo",
-    "poetry"
-  ],
-  "poetry": {
-    "labels": ["dependencies", "poetry"],
-    "updateLockFiles": true,
-    "rangeStrategy": "bump",
-    "bumpVersion": "patch",
-    "recreateWhen": "always",
-    "major": {
-      "automerge": false
-    },
-    "packageRules": [
-      {
-        "description": "merge minor and patch updates into a single PR",
-        "groupName": "poetry - all minor and patch updates",
-        "extends": ["schedule:automergeNonOfficeHours"],
-        "matchUpdateTypes": ["minor", "patch"],
-        "automerge": true,
-        "minimumReleaseAge": "3 days",
-        "addLabels": ["automerge"]
-      },
-      {
-        "matchPackageNames": ["python"],
-        "enabled": false
-      },
-      {
-        "description": "pin boto3 to prevent frequent releases being resolved by Poetry before passing minimum age",
-        "matchPackageNames": ["boto3"],
-        "rangeStrategy": "pin"
-      }
-    ]
-  }
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		"github>digicatapult/renovate-config"
+	],
+	"enabledManagers": [
+		"npm",
+		"dockerfile",
+		"docker-compose",
+		"github-actions",
+		"cargo",
+		"poetry"
+	],
+	"poetry": {
+		"labels": [
+			"dependencies",
+			"poetry"
+		],
+		"updateLockFiles": true,
+		"rangeStrategy": "bump",
+		"bumpVersion": "patch",
+		"recreateWhen": "always",
+		"major": {
+			"automerge": false
+		},
+		"packageRules": [
+			{
+				"description": "merge minor and patch updates into a single PR",
+				"groupName": "poetry - all minor and patch updates",
+				"extends": [
+					"schedule:automergeNonOfficeHours"
+				],
+				"matchUpdateTypes": [
+					"minor",
+					"patch"
+				],
+				"automerge": true,
+				"minimumReleaseAge": "3 days",
+				"addLabels": [
+					"automerge"
+				]
+			},
+			{
+				"matchPackageNames": [
+					"python"
+				],
+				"enabled": false
+			},
+			{
+				"description": "pin boto3 to prevent frequent releases being resolved by Poetry before passing minimum age",
+				"matchPackageNames": [
+					"boto3"
+				],
+				"rangeStrategy": "pin"
+			}
+		]
+	}
 }

--- a/poetry.json
+++ b/poetry.json
@@ -1,51 +1,42 @@
 {
-	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": [
-		"github>digicatapult/renovate-config"
-	],
-	"enabledManagers": [
-		"npm",
-		"dockerfile",
-		"docker-compose",
-		"github-actions",
-		"cargo",
-		"poetry"
-	],
-	"poetry": {
-		"labels": [
-			"dependencies",
-			"poetry"
-		],
-		"updateLockFiles": true,
-		"rangeStrategy": "bump",
-		"bumpVersion": "patch",
-		"recreateWhen": "always",
-		"major": {
-			"automerge": false
-		},
-		"packageRules": [
-			{
-				"description": "merge minor and patch updates into a single PR",
-				"groupName": "poetry - all minor and patch updates",
-				"extends": [
-					"schedule:automergeNonOfficeHours"
-				],
-				"matchUpdateTypes": [
-					"minor",
-					"patch"
-				],
-				"automerge": true,
-				"minimumReleaseAge": "3 days",
-				"addLabels": [
-					"automerge"
-				]
-			},
-			{
-				"matchPackageNames": [
-					"python"
-				],
-				"enabled": false
-			}
-		]
-	}
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>digicatapult/renovate-config"],
+  "enabledManagers": [
+    "npm",
+    "dockerfile",
+    "docker-compose",
+    "github-actions",
+    "cargo",
+    "poetry"
+  ],
+  "poetry": {
+    "labels": ["dependencies", "poetry"],
+    "updateLockFiles": true,
+    "rangeStrategy": "bump",
+    "bumpVersion": "patch",
+    "recreateWhen": "always",
+    "major": {
+      "automerge": false
+    },
+    "packageRules": [
+      {
+        "description": "merge minor and patch updates into a single PR",
+        "groupName": "poetry - all minor and patch updates",
+        "extends": ["schedule:automergeNonOfficeHours"],
+        "matchUpdateTypes": ["minor", "patch"],
+        "automerge": true,
+        "minimumReleaseAge": "3 days",
+        "addLabels": ["automerge"]
+      },
+      {
+        "matchPackageNames": ["python"],
+        "enabled": false
+      },
+      {
+        "description": "pin boto3 to prevent frequent releases being resolved by Poetry before passing minimum age",
+        "matchPackageNames": ["boto3"],
+        "rangeStrategy": "pin"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
# Pull Request

## Checklist
- [ ] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix
- [x] Chore
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

<!-- If this PR is linked to a JIRA ticket or Github Issue, please provide the ticket URL here. -->

## High level description

- Pin `boto3` updates because its frequent releases mean new versions are added during lockfile generation, causing Renovate artifact updates to fail because of the three-day minimum age.
- Happens because boto3 releases almost daily https://pypi.org/project/boto3/#history

## Detailed description


## Additional context

- [CDECatapult/das-cloud-db#142](https://github.com/CDECatapult/das-cloud-db/pull/142) demonstrates the artifact update failure.