### PR TITLE
feat: add merge-queue preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,47 @@ Behaviour:
 }
 ```
 
+#### Repositories using a GitHub merge queue
+
+Repositories on a merge queue need four changes to how Renovate behaves. Apply the `merge-queue` overlay **after** the base preset so its overrides win:
+
+```json
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		"github>digicatapult/renovate-config",
+		"github>digicatapult/renovate-config:merge-queue"
+	]
+}
+```
+
+It composes with the language presets in the same way, base first:
+
+```json
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		"github>digicatapult/renovate-config:poetry",
+		"github>digicatapult/renovate-config:merge-queue"
+	]
+}
+```
+
+Unlike the language presets, `merge-queue` deliberately does **not** extend the base preset itself. It is orthogonal to language, so it is an overlay rather than a variant.
+
+What it changes and why:
+
+| Setting | Base | Merge queue | Why |
+| --- | --- | --- | --- |
+| `bumpVersion` | `patch` | unset | Renovate writes the next version into the package file on its own branch. Two Renovate pull requests therefore compute the same version, and the second to reach the queue fails the version check and is evicted. Under merge queue versioning the number is applied on trunk after merge instead. |
+| `addLabels` | none | `v:patch` | Merge queue repositories gate pull requests on carrying exactly one `v:` label. Without this every Renovate pull request fails that gate and can never merge. |
+| `platformAutomerge` | Renovate default | `true` | Uses GitHub's own auto-merge, which routes the pull request **through the queue**. Merging via the Renovate API instead would either bypass the queue or be rejected by it. |
+| `rebaseWhen` | `behind-base-branch` (via `:rebaseStalePrs`) | `conflicted` | The queue tests each pull request against trunk itself, so rebasing merely to catch up is wasted CI. Worse, pushing to a branch that is sitting in the queue **evicts it**. Only rebase on a real conflict. |
+
+The `v:patch` label must exist in the repository.
+
+The branch protection settings listed under [Repository Setup](#repository-setup) also change for these repositories: "Require branches to be up to date before merging" is replaced by the queue and should be off, and `Check Version` is replaced by the version label check.
+
 ## Links
 
 - [Configuration Options](https://renovatebot.com/docs/configuration-options)

--- a/merge-queue.json
+++ b/merge-queue.json
@@ -1,0 +1,35 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"description": [
+		"Overlay for repositories using a GitHub merge queue.",
+		"Unlike the language presets, this one deliberately does NOT extend the base preset, because it is orthogonal to language. Apply it AFTER a base preset so its overrides win, e.g. extends: ['github>digicatapult/renovate-config', 'github>digicatapult/renovate-config:merge-queue'] or ['github>digicatapult/renovate-config:poetry', 'github>digicatapult/renovate-config:merge-queue']."
+	],
+
+	"addLabels": ["v:patch"],
+
+	"platformAutomerge": true,
+
+	"rebaseWhen": "conflicted",
+
+	"npm": {
+		"bumpVersion": null,
+		"lockFileMaintenance": {
+			"rebaseWhen": "conflicted"
+		}
+	},
+
+	"cargo": {
+		"bumpVersion": null,
+		"lockFileMaintenance": {
+			"rebaseWhen": "conflicted"
+		}
+	},
+
+	"nuget": {
+		"bumpVersion": null
+	},
+
+	"poetry": {
+		"bumpVersion": null
+	}
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "author": "Digital Catapult (https://www.digicatapult.org.uk/)",
   "scripts": {
-    "test": "renovate-config-validator default.json helm.json poetry.json flux.json"
+    "test": "renovate-config-validator default.json helm.json poetry.json flux.json merge-queue.json"
   },
   "devDependencies": {
     "renovate": "^43.285.7"


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Feature

## Linked tickets

- Companion to digicatapult/shared-workflows#122 and digicatapult/hello-world#29

## High level description

Adds a `merge-queue` preset for repositories running a GitHub merge queue. Purely additive: no repository's Renovate behaviour changes until it opts in by extending the new preset.

## Detailed description

Renovate needs four behavioural changes on a queue repository. The base preset cannot make them for everyone, because they are wrong for repositories that are **not** on a queue.

| Setting | Base | Overlay | Why |
| --- | --- | --- | --- |
| `bumpVersion` | `patch` | unset | **This is the important one.** The base preset has Renovate write the next version into the package file on its own branch. That is the exact collision merge queue versioning removes: two Renovate PRs compute the same version, and the second to reach the queue fails the version check and is evicted. |
| `addLabels` | none | `v:patch` | Queue repositories gate PRs on carrying exactly one `v:` label. **Without this every Renovate PR fails that gate and can never merge.** |
| `platformAutomerge` | Renovate default | `true` | Uses GitHub native auto-merge, which routes the PR through the queue. Merging via the Renovate API would either bypass the queue or be rejected by it. Made explicit rather than relying on a default. |
| `rebaseWhen` | `behind-base-branch` (from `:rebaseStalePrs`) | `conflicted` | The queue tests each PR against trunk itself, so catch-up rebases are wasted CI. Worse, pushing to a branch sitting in the queue **evicts it**. |

`bumpVersion` is unset for `npm`, `cargo`, `nuget` and `poetry`, and the `lockFileMaintenance` blocks that set `rebaseWhen: behind-base-branch` explicitly are overridden too.

**Composition.** Unlike `helm.json`, `poetry.json` and friends, this preset deliberately does **not** extend the base preset. Those are language variants; this is orthogonal to language, so it is an overlay applied after a base:

```json
{
	"extends": [
		"github>digicatapult/renovate-config:poetry",
		"github>digicatapult/renovate-config:merge-queue"
	]
}
```

Order matters, so the overlay must come last.

## Describe alternatives you've considered

**Changing the base preset directly.** Rejected: `bumpVersion: patch` is correct and necessary for every repository *not* on a queue, since it is how Renovate PRs satisfy `check-version` today. Removing it org-wide would break their releases.

**Having the overlay extend the base, matching the language presets.** Rejected: it would then conflict with `poetry`/`helm` rather than compose with them, and a poetry queue repo could not use both.

## Operational impact

None until a repository opts in. Adding the preset file changes nothing on its own.

For a repository that does opt in, `v:patch` must exist as a label, and its branch protection needs the queue changes described in the README (drop "Require branches to be up to date", replace `Check Version` with the version label check).

## Additional context

`merge-queue.json` was added to the `test` script and `renovate-config-validator` passes:

```
INFO: Validating merge-queue.json as global config
INFO: Config validated successfully against 5 file(s)
```

Noted in passing, **not** changed here: `terraform.json` is absent from that `test` script, so it is currently unvalidated. Worth a follow-up.
